### PR TITLE
Update Zitierstil von Prof. Helmig

### DIFF
--- a/universitat-mannheim-lehrstuhl-prof-helmig.csl
+++ b/universitat-mannheim-lehrstuhl-prof-helmig.csl
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<style class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE" xmlns="http://purl.org/net/xbiblio/csl">
-<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+﻿<?xml version="1.0" encoding="utf-8"?>
+<style class="note" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE" xmlns="http://purl.org/net/xbiblio/csl">
+  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Universität Mannheim - Lehrstuhl Prof. Helmig (German)</title>
     <id>http://www.zotero.org/styles/universitat-mannheim-lehrstuhl-prof-helmig</id>
     <link href="http://www.zotero.org/styles/universitat-mannheim-lehrstuhl-prof-helmig" rel="self"/>
-    <link href="http://helmig.bwl.uni-mannheim.de/fileadmin/_migrated/content_uploads/Richtlinien_LS_Helmig_03.pdf" rel="documentation"/>
-    <link href="http://helmig.bwl.uni-mannheim.de/fileadmin/_migrated/content_uploads/Richtlinien_LS_Helmig_05.pdf" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/apa" rel="template"/>
+    <link href="https://helmig.bwl.uni-mannheim.de/fileadmin/files/helmig/files/lehre/Richtlinien_LS_Helmig.pdf" rel="documentation"/>
     <author>
       <name>Philipp Zumstein</name>
       <uri>https://github.com/zuphilip</uri>
@@ -14,10 +14,22 @@
     <category citation-format="note"/>
     <category field="communications"/>
     <category field="social_science"/>
-    <summary>Zitierstil implemeniert die Richtlinien zur formalen Gestaltung von schriftlichen Arbeiten (Stand Dezember 2013) am Lehrstuhl von Prof. Helmig, BWL, Universität Mannheim</summary>
-    <updated>2014-09-30T11:50:15+00:00</updated>
+    <summary>Zitierstil implemeniert die Richtlinien zur formalen Gestaltung von schriftlichen Arbeiten (Stand März 2017) am Lehrstuhl von Prof. Helmig, BWL, Universität Mannheim. Der Zitierstil orientiert sich an APA und scheint jetzt mit ein paar kleinen Änderungen als APA-Adaption gut zu passen.</summary>
+    <updated>2017-04-05T06:43:51+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>trans.</single>
+        <multiple>trans.</multiple>
+      </term>
+    </terms>
+  </locale>
   <locale xml:lang="de-DE">
     <terms>
       <term name="accessed">Zugriff am</term>
@@ -25,243 +37,612 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
-  <macro name="editor">
-    <names variable="editor">
-      <label form="short" text-case="lowercase" suffix=" "/>
-      <name and="text" name-as-sort-order="all"/>
-    </names>
-  </macro>
-  <macro name="series-editor">
-    <names variable="original-author">
-      <label form="short" text-case="capitalize-first" suffix=". " strip-periods="true"/>
-      <name and="text" delimiter=", "/>
-    </names>
-  </macro>
-  <macro name="author">
+  <macro name="container-contributors">
     <choose>
-      <if match="any" variable="author editor">
-        <names variable="author">
-          <name delimiter="/" delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
-          <label form="short" strip-periods="true" prefix=" [" suffix="]"/>
-          <substitute>
-            <names variable="editor"/>
-          </substitute>
-        </names>
+      <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+        <group delimiter=", ">
+          <names variable="container-author" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=" (" text-case="title" suffix=")"/>
+          </names>
+          <names variable="editor translator" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=" (" text-case="title" suffix=")"/>
+          </names>
+        </group>
       </if>
-      <else>
-        <text term="anonymous" form="short"/>
-      </else>
     </choose>
   </macro>
-  <macro name="author-short">
+  <macro name="secondary-contributors">
     <choose>
-      <if match="any" variable="author editor">
-        <names variable="author">
-          <name form="short" delimiter="/" delimiter-precedes-last="always"/>
-          <substitute>
-            <names variable="editor"/>
-          </substitute>
-        </names>
+      <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
+        <group delimiter=", " prefix=" (" suffix=")">
+          <names variable="container-author" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+          <names variable="editor translator" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="symbol" delimiter-precedes-last="never" initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else-if type="legal_case">
+            <text variable="title" font-style="italic"/>
+          </else-if>
+          <else-if type="book graphic  motion_picture song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </else-if>
+          <else-if type="bill legislation" match="any">
+            <text variable="title" form="short"/>
+          </else-if>
+          <else-if variable="reviewed-author">
+            <choose>
+              <if variable="reviewed-title" match="none">
+                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+              </if>
+              <else>
+                <text variable="title" form="short" quotes="true"/>
+              </else>
+            </choose>
+          </else-if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="thesis report" match="any">
+        <choose>
+          <if variable="DOI" match="any">
+            <text variable="DOI" prefix="https://doi.org/"/>
+          </if>
+          <else-if variable="archive" match="any">
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="archive" suffix="."/>
+              <text variable="archive_location" prefix=" (" suffix=")"/>
+            </group>
+          </else-if>
+          <else>
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else>
+        </choose>
       </if>
       <else>
-        <text term="anonymous" form="short" strip-periods="true"/>
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="https://doi.org/"/>
+          </if>
+          <else>
+            <choose>
+              <if type="webpage">
+                <group delimiter=" ">
+                  <text variable="URL" suffix="."/>
+                  <text term="accessed" suffix=" "/>
+                  <date form="text" variable="accessed"/>
+                </group>
+              </if>
+              <else>
+                <group>
+                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+                  <text term="from" suffix=" "/>
+                  <text variable="URL"/>
+                </group>
+              </else>
+            </choose>
+          </else>
+        </choose>
       </else>
     </choose>
   </macro>
   <macro name="title">
     <choose>
-      <if type="thesis"/>
-      <else-if type="bill book graphic legal_case motion_picture report song" match="any">
-        <text variable="title"/>
+      <if type="book graphic manuscript motion_picture report song speech thesis" match="any">
+        <choose>
+          <if variable="version" type="book" match="all">
+            <text variable="title"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </if>
+      <else-if variable="reviewed-author">
+        <choose>
+          <if variable="reviewed-title">
+            <group delimiter=" ">
+              <text variable="title"/>
+              <group delimiter=", " prefix="[" suffix="]">
+                <text variable="reviewed-title" font-style="italic" prefix="Review of "/>
+                <names variable="reviewed-author" delimiter=", ">
+                  <label form="verb-short" suffix=" "/>
+                  <name and="symbol" initialize-with=". " delimiter=", "/>
+                </names>
+              </group>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", " prefix="[" suffix="]">
+              <text variable="title" font-style="italic" prefix="Review of "/>
+              <names variable="reviewed-author" delimiter=", ">
+                <label form="verb-short" suffix=" "/>
+                <name and="symbol" initialize-with=". " delimiter=", "/>
+              </names>
+            </group>
+          </else>
+        </choose>
       </else-if>
       <else>
-        <text variable="title" quotes="false"/>
+        <text variable="title"/>
       </else>
+    </choose>
+  </macro>
+  <macro name="title-plus-extra">
+    <text macro="title"/>
+    <choose>
+      <if type="report thesis" match="any">
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <group delimiter=" ">
+            <choose>
+              <if variable="genre" match="any">
+                <text variable="genre"/>
+              </if>
+              <else>
+                <text variable="collection-title"/>
+              </else>
+            </choose>
+            <text variable="number" prefix="No. "/>
+          </group>
+          <group delimiter=" ">
+            <text term="version" text-case="capitalize-first"/>
+            <text variable="version"/>
+          </group>
+          <text macro="edition"/>
+        </group>
+      </if>
+      <else-if type="post-weblog webpage" match="any">
+        <text variable="genre" prefix=" [" suffix="]"/>
+      </else-if>
+      <else-if variable="version">
+        <group delimiter=" " prefix=" (" suffix=")">
+          <text term="version" text-case="capitalize-first"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+    </choose>
+    <text macro="format" prefix=" [" suffix="]"/>
+  </macro>
+  <macro name="format">
+    <choose>
+      <if match="any" variable="medium">
+        <text variable="medium" text-case="capitalize-first"/>
+      </if>
+      <else-if type="dataset" match="any">
+        <text value="Data set"/>
+      </else-if>
     </choose>
   </macro>
   <macro name="publisher">
-    <group delimiter=": ">
-      <text variable="publisher-place"/>
-      <text variable="publisher"/>
-    </group>
-  </macro>
-  <macro name="year-date">
     <choose>
-      <if variable="issued">
+      <if type="report" match="any">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else-if type="thesis" match="any">
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </else-if>
+      <else-if type="post-weblog webpage" match="none">
+        <group delimiter=", ">
+          <choose>
+            <if variable="event version" type="speech motion_picture" match="none">
+              <text variable="genre"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="article-journal article-magazine" match="none">
+              <group delimiter=": ">
+                <choose>
+                  <if variable="publisher-place">
+                    <text variable="publisher-place"/>
+                  </if>
+                  <else>
+                    <text variable="event-place"/>
+                  </else>
+                </choose>
+                <text variable="publisher"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="container-title" match="none">
+        <choose>
+          <if variable="event">
+            <choose>
+              <if variable="genre" match="none">
+                <text term="presented at" text-case="capitalize-first" suffix=" "/>
+                <text variable="event"/>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <text term="presented at"/>
+                  <text variable="event"/>
+                </group>
+              </else>
+            </choose>
+          </if>
+          <else-if type="speech">
+            <text variable="genre" text-case="capitalize-first"/>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="issued">
+            <group prefix=" (" suffix=")">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix"/>
+              <choose>
+                <if type="speech" match="any">
+                  <date variable="issued">
+                    <date-part prefix=", " name="month"/>
+                  </date>
+                </if>
+                <else-if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
+                  <date variable="issued">
+                    <date-part prefix=", " name="month"/>
+                    <date-part prefix=" " name="day"/>
+                  </date>
+                </else-if>
+              </choose>
+            </group>
+          </if>
+          <else-if variable="status">
+            <group prefix=" (" suffix=")">
+              <text variable="status"/>
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else-if>
+          <else>
+            <group prefix=" (" suffix=")">
+              <text term="no date" form="short"/>
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued-sort">
+    <choose>
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part name="month"/>
+          <date-part name="day"/>
+        </date>
+      </if>
+      <else>
         <date variable="issued">
           <date-part name="year"/>
         </date>
-      </if>
-      <else>
-        <text term="no date" form="short"/>
       </else>
     </choose>
   </macro>
-  <macro name="day-month">
+  <macro name="issued-year">
     <choose>
-      <if match="any" is-numeric="issue">
-        <text variable="issue" prefix=", "/>
+      <if variable="issued">
+        <group delimiter="/">
+          <date variable="original-date" form="text"/>
+          <group>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+            <text variable="year-suffix"/>
+          </group>
+        </group>
       </if>
-      <else-if match="any" variable="issue">
-        <text variable="issue" prefix=" (" suffix=")"/>
+      <else-if variable="status">
+        <text variable="status"/>
+        <text variable="year-suffix" prefix="-"/>
       </else-if>
       <else>
-        <date variable="issued">
-          <date-part name="month"/>
-        </date>
+        <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix="-"/>
       </else>
     </choose>
-  </macro>
-  <macro name="pages">
-    <group delimiter=" ">
-      <label variable="page" form="short" suffix=". " text-case="capitalize-first" strip-periods="true"/>
-      <text variable="page"/>
-    </group>
   </macro>
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
         <group delimiter=" ">
           <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short" suffix="," strip-periods="true"/>
+          <text term="edition" form="short"/>
         </group>
       </if>
       <else>
-        <text variable="edition" suffix="."/>
+        <text variable="edition"/>
       </else>
     </choose>
   </macro>
-  <macro name="author-count">
-    <names variable="author">
-      <name form="count"/>
-    </names>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <group prefix=", " delimiter=", ">
+          <group>
+            <text variable="volume" font-style="italic"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+        </group>
+        <choose>
+          <if variable="issued">
+            <choose>
+              <if variable="page issue" match="none">
+                <text variable="status" prefix=". "/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </if>
+      <else-if type="article-newspaper">
+        <group delimiter=" " prefix=", ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="book graphic motion_picture report song chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <choose>
+            <if type="report" match="none">
+              <text macro="edition"/>
+            </if>
+          </choose>
+          <choose>
+            <if variable="volume" match="any">
+              <group>
+                <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                <number variable="volume" form="numeric"/>
+              </group>
+            </if>
+            <else>
+              <group>
+                <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
+              </group>
+            </else>
+          </choose>
+          <group>
+            <label variable="page" form="short" suffix=" "/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="legal_case">
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="authority"/>
+          <choose>
+            <if variable="container-title" match="any">
+              <date variable="issued" form="numeric" date-parts="year"/>
+            </if>
+            <else>
+              <date variable="issued" form="text"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+      <else-if type="bill legislation" match="any">
+        <date variable="issued" prefix=" (" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+    </choose>
   </macro>
-  <macro name="locator">
-    <group delimiter=" ">
-      <label variable="locator" form="short"/>
-      <text variable="locator"/>
+  <macro name="citation-locator">
+    <group>
+      <choose>
+        <if locator="chapter">
+          <label variable="locator" form="long" text-case="capitalize-first"/>
+        </if>
+        <else>
+          <label variable="locator" form="short"/>
+        </else>
+      </choose>
+      <text variable="locator" prefix=" "/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year">
-    <sort>
-      <key macro="year-date"/>
-    </sort>
-    <layout delimiter="; " suffix=".">
-      <group delimiter=", ">
-        <choose>
-          <if type="webpage" match="any">
-            <group delimiter=", ">
-              <text macro="author-short"/>
-              <text variable="URL"/>
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </group>
-          </if>
-          <else-if type="legislation" match="any">
-            <group delimiter=" ">
-              <text macro="locator"/>
-              <text variable="container-title"/>
+  <macro name="container">
+    <choose>
+      <if type="post-weblog webpage" match="none">
+        <group>
+          <choose>
+            <if type="chapter paper-conference entry-encyclopedia" match="any">
+              <text term="in" text-case="capitalize-first" suffix=" "/>
+            </if>
+          </choose>
+          <group delimiter=", ">
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <text macro="container-title"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper" match="any">
+        <text variable="container-title" font-style="italic" text-case="title"/>
+      </if>
+      <else-if type="bill legal_case legislation" match="none">
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="legal-cites">
+    <choose>
+      <if type="legal_case" match="any">
+        <group prefix=", " delimiter=" ">
+          <choose>
+            <if variable="container-title">
               <text variable="volume"/>
-            </group>
-          </else-if>
-          <else>
-            <group delimiter=" ">
-              <text macro="author-short"/>
-              <text macro="year-date"/>
-            </group>
-            <text macro="locator"/>
-          </else>
-        </choose>
-      </group>
-    </layout>
-  </citation>
-  <bibliography>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <text variable="page"/>
+            </if>
+            <else>
+              <text variable="number" prefix="No. "/>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else-if type="bill legislation" match="any">
+        <group delimiter=", " prefix=", ">
+          <choose>
+            <if variable="number">
+              <text variable="number" prefix="Pub. L. No. "/>
+              <group delimiter=" ">
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <text variable="page-first"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="original-date">
+    <choose>
+      <if variable="original-date">
+        <group prefix="(" suffix=")" delimiter=" ">
+          <text value="Original work published"/>
+          <date variable="original-date" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name" collapse="year">
     <sort>
       <key macro="author"/>
-      <key macro="year-date"/>
+      <key macro="issued-sort"/>
     </sort>
-    <layout suffix=".">
-      <group delimiter=", ">
-        <group delimiter=" ">
+    <layout delimiter="; " suffix=".">
+      <choose>
+        <if type="legislation" match="any">
+          <group delimiter=" ">
+            <text variable="locator"/>
+            <text variable="container-title"/>
+            <text variable="volume"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text macro="author-short"/>
+              <text macro="issued-year" prefix="(" suffix=")"/>
+            </group>
+            <text macro="citation-locator"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography et-al-use-last="true" entry-spacing="0" line-spacing="2" hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort" sort="ascending"/>
+      <key macro="title"/>
+    </sort>
+    <layout>
+      <group suffix=".">
+        <group delimiter=". ">
           <text macro="author"/>
-          <text macro="year-date" prefix="(" suffix=")"/>
+          <text macro="issued"/>
+          <text macro="title-plus-extra"/>
+          <text macro="container"/>
         </group>
-        <text variable="title"/>
-        <choose>
-          <if type="article-magazine article-journal" match="any">
-            <group delimiter=": ">
-              <text term="in"/>
-              <text variable="container-title"/>
-            </group>
-            <group delimiter=" ">
-              <text term="volume" form="short"/>
-              <text variable="volume"/>
-            </group>
-            <group delimiter=" ">
-              <text term="issue" form="short"/>
-              <text variable="issue"/>
-            </group>
-            <text macro="pages"/>
-          </if>
-          <else-if type="article-newspaper" match="any">
-            <group delimiter=": ">
-              <text term="in"/>
-              <text variable="container-title"/>
-            </group>
-            <date form="text" date-parts="year-month-day" variable="issued"/>
-            <text variable="section"/>
-            <text macro="pages"/>
-          </else-if>
-          <else-if type="thesis">
-            <text variable="genre"/>
-            <text macro="publisher"/>
-          </else-if>
-          <else-if type="chapter paper-conference" match="any">
-            <group delimiter=": ">
-              <text term="in" text-case="lowercase"/>
-              <group delimiter=": ">
-                <names variable="container-author">
-                  <name delimiter="/" initialize-with="." name-as-sort-order="all"/>
-                  <label form="short" prefix=" (" suffix=")"/>
-                  <substitute>
-                    <names variable="editor"/>
-                  </substitute>
-                </names>
-                <text variable="container-title"/>
-              </group>
-            </group>
-            <text macro="edition"/>
-            <text variable="publisher-place"/>
-            <group delimiter=" ">
-              <text term="page" form="short"/>
-              <text variable="page"/>
-            </group>
-          </else-if>
-          <else-if type="webpage" match="any">
-            <text variable="URL"/>
-            <date form="numeric" variable="accessed" prefix="(" suffix=")"/>
-          </else-if>
-          <else-if type="legislation" match="any">
-            <group delimiter=" " suffix=":">
-              <text variable="container-title"/>
-              <text variable="volume"/>
-              <date variable="issued" prefix="(" suffix=")">
-                <date-part name="year"/>
-              </date>
-            </group>
-            <date form="text" variable="issued" prefix="vom "/>
-            <text variable="section" prefix="(" suffix=")"/>
-            <text variable="references"/>
-          </else-if>
-          <else>
-            <text macro="editor"/>
-            <text macro="edition"/>
-            <text variable="publisher-place"/>
-          </else>
-        </choose>
+        <text macro="legal-cites"/>
+        <text macro="locators"/>
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
       </group>
+      <text macro="access" prefix=" "/>
+      <text macro="original-date" prefix=" "/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Der Zitierstil hat sich in den letzten Jahren
sehr verändert:
 * Das Literaturverzeichnis orientiert sich an APA und weicht
davon nur geringfügig ab.
 * Die Autorennamen werden nicht mehr mit Schrägstrichen getrennt.